### PR TITLE
Refine lands page filters and layout

### DIFF
--- a/static/css/lands.css
+++ b/static/css/lands.css
@@ -1,0 +1,337 @@
+/* Lands page layout and filter styling */
+
+.page-lands main.md3-container {
+  padding-top: var(--md-sys-spacing-4);
+}
+
+.page-lands .md3-page-header {
+  padding: var(--md-sys-spacing-4) 0 var(--md-sys-spacing-4);
+  margin-bottom: var(--md-sys-spacing-5);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.page-lands .md3-page-title {
+  margin-bottom: var(--md-sys-spacing-1);
+}
+
+.page-lands .page-subtitle {
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.lands-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md-sys-spacing-6);
+}
+
+.filters-panel {
+  background-color: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-large);
+  padding: var(--md-sys-spacing-4) var(--md-sys-spacing-5);
+  box-shadow: var(--md-sys-elevation-1);
+}
+
+.filters-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md-sys-spacing-4);
+}
+
+.filters-form__top-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--md-sys-spacing-4);
+  flex-wrap: wrap;
+}
+
+.filters-form__title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-2);
+  color: var(--md-sys-color-on-surface);
+}
+
+.filters-form__title .title-medium {
+  margin: 0;
+}
+
+.filters-form__title .material-symbols-outlined {
+  color: var(--md-sys-color-primary);
+}
+
+.filters-form__fields {
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-3);
+  flex-wrap: wrap;
+}
+
+.filters-form__field {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-2);
+  background-color: var(--md-sys-color-surface-container-highest);
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: var(--md-sys-shape-corner-medium);
+  padding: 0 var(--md-sys-spacing-3);
+  height: 48px;
+  flex: 1 1 160px;
+  min-width: 160px;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.filters-form__field--grow {
+  flex: 2 1 280px;
+  min-width: 240px;
+}
+
+.filters-form__field--sort {
+  flex: 1.4 1 220px;
+  min-width: 220px;
+  padding-right: var(--md-sys-spacing-1);
+}
+
+.filters-form__field--select::after {
+  content: 'expand_more';
+  font-family: 'Material Symbols Outlined';
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  position: absolute;
+  right: var(--md-sys-spacing-2);
+  pointer-events: none;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 20px;
+}
+
+.filters-form__field--select select {
+  padding-right: var(--md-sys-spacing-6);
+}
+
+.filters-form__field--select:focus-within::after {
+  color: var(--md-sys-color-primary);
+}
+
+.filters-form__field:focus-within {
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--md-sys-color-primary) 65%, transparent);
+}
+
+.filters-form__field input,
+.filters-form__field select {
+  border: none;
+  background: transparent;
+  color: var(--md-sys-color-on-surface);
+  font: var(--md-sys-typescale-body-large);
+  width: 100%;
+  height: 100%;
+  padding: 0;
+}
+
+.filters-form__field select {
+  cursor: pointer;
+}
+
+.filters-form__field--select select {
+  appearance: none;
+}
+
+.filters-form__field input::placeholder {
+  color: color-mix(in srgb, var(--md-sys-color-on-surface) 60%, transparent);
+}
+
+.filters-form__field input:focus,
+.filters-form__field select:focus {
+  outline: none;
+}
+
+.filters-form__icon {
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.filters-form__field:focus-within .filters-form__icon {
+  color: var(--md-sys-color-primary);
+}
+
+.filters-form__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-2);
+  padding: 0 var(--md-sys-spacing-3);
+  height: 48px;
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: var(--md-sys-shape-corner-medium);
+  background-color: var(--md-sys-color-surface-container-highest);
+  color: var(--md-sys-color-on-surface);
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.filters-form__checkbox:focus-within {
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--md-sys-color-primary) 65%, transparent);
+}
+
+.filters-form__checkbox input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--md-sys-color-primary);
+}
+
+.filters-form__checkbox .material-symbols-outlined {
+  color: var(--md-sys-color-primary);
+  font-size: 20px;
+}
+
+.filters-form__order {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-1);
+  margin-left: var(--md-sys-spacing-2);
+  padding-left: var(--md-sys-spacing-2);
+  border-left: 1px solid var(--md-sys-color-outline-variant);
+  height: 100%;
+}
+
+.filters-form__order .md3-button--icon {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--md-sys-shape-corner-small);
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.filters-form__order .md3-button--icon.md3-button--filled {
+  color: var(--md-sys-color-on-primary);
+}
+
+.filters-form__actions-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-2);
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
+.filters-form__actions-group .md3-button {
+  min-height: 40px;
+}
+
+.toggle-group {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-large);
+  overflow: hidden;
+  background-color: color-mix(in srgb, var(--md-sys-color-surface) 70%, transparent);
+}
+
+.toggle-group .md3-button--icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 0;
+  border: none;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.toggle-group .md3-button--icon + .md3-button--icon {
+  border-left: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.toggle-group .md3-button--icon.md3-button--filled {
+  color: var(--md-sys-color-on-primary);
+  background-color: var(--md-sys-color-primary);
+}
+
+.lands-results {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--md-sys-spacing-4);
+  flex-wrap: wrap;
+}
+
+.lands-results__summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md-sys-spacing-1);
+}
+
+.lands-results__status {
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.lands-results__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-3);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.page-lands .table-responsive {
+  border-radius: var(--md-sys-shape-corner-medium);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background-color: var(--md-sys-color-surface-container);
+  overflow: hidden;
+}
+
+.page-lands .table-responsive table {
+  width: 100%;
+}
+
+@media (max-width: 992px) {
+  .filters-form__fields {
+    gap: var(--md-sys-spacing-2);
+  }
+
+  .filters-form__actions-group {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .filters-form__fields {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filters-form__field,
+  .filters-form__field--grow,
+  .filters-form__field--sort {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .filters-form__checkbox {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .filters-form__actions-group {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .toggle-group {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 600px) {
+  .filters-form__top-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .lands-results {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .lands-results__controls {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1129,6 +1129,15 @@ function saveEnvironment(event, landId) {
     });
 }
 
+// Keep hidden view_type input in sync with current selection
+IdealistaApp.updateViewTypeInput = function(viewType) {
+        const viewInput = document.querySelector('#filter-form input[name="view_type"]');
+
+        if (viewInput) {
+            viewInput.value = viewType;
+        }
+};
+
 // View switching functionality - extend IdealistaApp
 IdealistaApp.switchView = function(viewType) {
         const listView = document.getElementById('list-view');
@@ -1181,9 +1190,10 @@ IdealistaApp.switchView = function(viewType) {
             cardsBtn.classList.add('md3-button--filled');
             listBtn.classList.remove('md3-button--filled');
         }
-        
+
         // Update URL without page reload
         IdealistaApp.updateViewTypeInUrl(viewType);
+        this.updateViewTypeInput(viewType);
 };
 
 // Update view type in URL - extend IdealistaApp
@@ -1263,6 +1273,9 @@ IdealistaApp.initializeViewOnLoad = function() {
                 listBtn.classList.remove('md3-button--filled');
             }
         }
+
+        const activeView = listView.style.display !== 'none' ? 'list' : 'cards';
+        this.updateViewTypeInput(activeView);
 };
 
 // Setup view switching - extend IdealistaApp

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,7 @@
     <!-- Custom MD3 Theme CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/md3-theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/md3-components.css') }}">
+    {% block styles %}{% endblock %}
     
     <script>
         function setLanguage(langCode) {
@@ -37,7 +38,7 @@
         }
     </script>
 </head>
-<body>
+<body{% block body_attrs %}{% endblock %}>
     <!-- MD3 Navigation -->
     <header class="md3-top-app-bar">
         <div class="md3-top-app-bar__title">

--- a/templates/lands.html
+++ b/templates/lands.html
@@ -2,10 +2,14 @@
 
 {% block title %}Properties - Idealista Land Watch{% endblock %}
 
+{% block styles %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/lands.css') }}">
+{% endblock %}
+
+{% block body_attrs %} class="page-lands"{% endblock %}
+
 {% block content %}
-<!-- MD3 Container -->
-<div class="md3-container">
-    <!-- MD3 Page Header -->
+<div class="md3-container lands-page">
     <header class="md3-page-header md3-page-header--compact">
         <div class="md3-page-title">
             <span class="material-symbols-outlined">apartment</span>
@@ -16,232 +20,201 @@
                 <span class="md3-badge md3-secondary-container">{{ lands|length }}</span>
             {% endif %}
         </div>
-        <div class="body-small" style="color: var(--md-sys-color-on-surface-variant); margin-top: var(--md-sys-spacing-1);">
+        <p class="body-small page-subtitle">
             {{ t('last_sync') }}: <span id="last-sync" class="label-medium">{{ t('loading') }}...</span>
-        </div>
+        </p>
     </header>
 
+    <section class="filters-panel">
+        <form method="GET" id="filter-form" class="filters-form">
+            <input type="hidden" name="mode" value="{{ current_filters.mode or 'combined' }}">
+            <input type="hidden" name="view_type" value="{{ current_filters.view_type or 'cards' }}">
 
-    <!-- MD3 Filters Card -->
-    <div class="md3-card md3-card--elevated" style="margin-bottom: var(--md-sys-spacing-8);">
-        <div class="md3-card__header">
-            <h2 class="title-medium" style="display: flex; align-items: center; gap: var(--md-sys-spacing-2); margin: 0;">
-                <span class="material-symbols-outlined" style="color: var(--md-sys-color-primary);">tune</span>
-                {{ t('filters_search') }}
-            </h2>
-        </div>
-        <div class="md3-card__content">
-            <form method="GET" id="filter-form">
-                <!-- Hidden inputs to preserve state -->
-                <input type="hidden" name="mode" value="{{ current_filters.mode or 'combined' }}">
-                <input type="hidden" name="view_type" value="{{ current_filters.view_type or 'cards' }}">
-                
-                <!-- Filter Fields Grid -->
-                <div class="md3-grid md3-filters-grid" style="gap: var(--md-sys-spacing-4); align-items: end; margin-bottom: var(--md-sys-spacing-6);">
-                    <!-- Search Field -->
-                    <div class="md3-text-field">
-                        <label class="md3-text-field__label" for="search">
-                            <span class="material-symbols-outlined" style="font-size: 18px; vertical-align: middle; margin-right: var(--md-sys-spacing-1);">search</span>
-                            {{ t('search_properties') }}
-                        </label>
-                        <input type="text" class="md3-text-field__input body-large" id="search" name="search" 
-                               value="{{ current_filters.search or '' }}">
-                    </div>
-                    
-                    <!-- Land Type Field -->
-                    <div class="md3-text-field">
-                        <label class="md3-text-field__label" for="land_type">
-                            <span class="material-symbols-outlined" style="font-size: 18px; vertical-align: middle; margin-right: var(--md-sys-spacing-1);">category</span>
-                            {{ t('land_type') }}
-                        </label>
-                        <select class="md3-text-field__input body-large" id="land_type" name="land_type">
-                            <option value="">{{ t('land_type_all') }}</option>
-                            <option value="developed" {{ 'selected' if current_filters.land_type == 'developed' }}>
-                                {{ t('developed') }}
+            <div class="filters-form__top-row">
+                <div class="filters-form__title">
+                    <span class="material-symbols-outlined">tune</span>
+                    <h2 class="title-medium">{{ t('filters_search') }}</h2>
+                </div>
+                <div class="filters-form__view-toggle toggle-group" role="group" aria-label="View type">
+                    <button type="button"
+                            class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.view_type == 'list' else '' }}"
+                            id="view-list-btn"
+                            onclick="switchView('list')"
+                            title="Table view - Compact data in rows">
+                        <span class="material-symbols-outlined">view_list</span>
+                    </button>
+                    <button type="button"
+                            class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.view_type == 'cards' or not current_filters.view_type else '' }}"
+                            id="view-cards-btn"
+                            onclick="switchView('cards')"
+                            title="Card view - Visual property cards">
+                        <span class="material-symbols-outlined">view_module</span>
+                    </button>
+                </div>
+            </div>
+
+            <div class="filters-form__fields">
+                <div class="filters-form__field filters-form__field--grow">
+                    <span class="material-symbols-outlined filters-form__icon">search</span>
+                    <input type="text"
+                           id="search"
+                           name="search"
+                           placeholder="{{ t('search_properties') }}"
+                           aria-label="{{ t('search_properties') }}"
+                           value="{{ current_filters.search or '' }}">
+                </div>
+
+                <div class="filters-form__field filters-form__field--select">
+                    <span class="material-symbols-outlined filters-form__icon">category</span>
+                    <select id="land_type"
+                            name="land_type"
+                            aria-label="{{ t('land_type') }}">
+                        <option value="">{{ t('land_type_all') }}</option>
+                        <option value="developed" {{ 'selected' if current_filters.land_type == 'developed' }}>
+                            {{ t('developed') }}
+                        </option>
+                        <option value="buildable" {{ 'selected' if current_filters.land_type == 'buildable' }}>
+                            {{ t('buildable') }}
+                        </option>
+                    </select>
+                </div>
+
+                <div class="filters-form__field filters-form__field--select">
+                    <span class="material-symbols-outlined filters-form__icon">location_on</span>
+                    <select id="municipality"
+                            name="municipality"
+                            aria-label="{{ t('location') }}">
+                        <option value="">{{ t('all_municipalities') }}</option>
+                        {% for municipality in municipalities %}
+                            <option value="{{ municipality }}" {{ 'selected' if current_filters.municipality == municipality }}>
+                                {{ municipality }}
                             </option>
-                            <option value="buildable" {{ 'selected' if current_filters.land_type == 'buildable' }}>
-                                {{ t('buildable') }}
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <label class="filters-form__checkbox" for="sea_view">
+                    <input type="checkbox"
+                           id="sea_view"
+                           name="sea_view"
+                           {{ 'checked' if current_filters.sea_view }}>
+                    <span class="material-symbols-outlined">waves</span>
+                    <span class="label-medium">{{ t('sea_view_only') }}</span>
+                </label>
+
+                <div class="filters-form__field filters-form__field--sort">
+                    <span class="material-symbols-outlined filters-form__icon">sort</span>
+                    <select id="sort"
+                            name="sort"
+                            aria-label="{{ t('sort_by') }}">
+                        <option value="" {{ 'selected' if not current_filters.sort_by else '' }}>{{ t('sort_by') }}</option>
+                        {% if current_filters.mode == 'investment' %}
+                            <option value="score_investment" {{ 'selected' if current_filters.sort_by == 'score_investment' }}>
+                                Investment Score
                             </option>
-                        </select>
-                    </div>
-                    
-                    <!-- Municipality Field -->
-                    <div class="md3-text-field">
-                        <label class="md3-text-field__label" for="municipality">
-                            <span class="material-symbols-outlined" style="font-size: 18px; vertical-align: middle; margin-right: var(--md-sys-spacing-1);">location_on</span>
-                            {{ t('location') }}
-                        </label>
-                        <select class="md3-text-field__input body-large" id="municipality" name="municipality">
-                            <option value="">{{ t('all_municipalities') }}</option>
-                            {% for municipality in municipalities %}
-                                <option value="{{ municipality }}" 
-                                        {{ 'selected' if current_filters.municipality == municipality }}>
-                                    {{ municipality }}
-                                </option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                    
-                    <!-- Sea View Checkbox -->
-                    <div style="display: flex; align-items: center; gap: var(--md-sys-spacing-2); white-space: nowrap;">
-                        <input type="checkbox" id="sea_view" name="sea_view" 
-                               {{ 'checked' if current_filters.sea_view }}
-                               style="accent-color: var(--md-sys-color-primary);">
-                        <label class="label-medium" for="sea_view" style="color: var(--md-sys-color-on-surface); cursor: pointer; display: flex; align-items: center; gap: var(--md-sys-spacing-1);">
-                            <span class="material-symbols-outlined" style="font-size: 18px; color: var(--md-sys-color-primary);">waves</span>
-                            {{ t('sea_view_only') }}
-                        </label>
-                    </div>
-                    
-                    <!-- Sort Controls -->
-                    <div style="display: flex; gap: var(--md-sys-spacing-2); align-items: end;">
-                        <div class="md3-text-field" style="flex: 1;">
-                            <label class="md3-text-field__label" for="sort">
-                                <span class="material-symbols-outlined" style="font-size: 18px; vertical-align: middle; margin-right: var(--md-sys-spacing-1);">sort</span>
-                                {{ t('sort_by') }}
-                            </label>
-                            <select class="md3-text-field__input body-large" id="sort" name="sort">
-                                <option value="" {{ 'selected' if not current_filters.sort_by else '' }}>{{ t('sort_by') }}</option>
-                                <!-- Mode-based score options -->
-                                {% if current_filters.mode == 'investment' %}
-                                    <option value="score_investment" {{ 'selected' if current_filters.sort_by == 'score_investment' }}>
-                                        Investment Score
-                                    </option>
-                                    <option value="score_lifestyle" {{ 'selected' if current_filters.sort_by == 'score_lifestyle' }}>
-                                        Lifestyle Score
-                                    </option>
-                                    <option value="score_total" {{ 'selected' if current_filters.sort_by == 'score_total' }}>
-                                        Combined Score
-                                    </option>
-                                {% elif current_filters.mode == 'lifestyle' %}
-                                    <option value="score_lifestyle" {{ 'selected' if current_filters.sort_by == 'score_lifestyle' }}>
-                                        Lifestyle Score
-                                    </option>
-                                    <option value="score_investment" {{ 'selected' if current_filters.sort_by == 'score_investment' }}>
-                                        Investment Score
-                                    </option>
-                                    <option value="score_total" {{ 'selected' if current_filters.sort_by == 'score_total' }}>
-                                        Combined Score
-                                    </option>
-                                {% else %}
-                                    <option value="score_total" {{ 'selected' if current_filters.sort_by == 'score_total' }}>
-                                        Combined Score
-                                    </option>
-                                    <option value="score_investment" {{ 'selected' if current_filters.sort_by == 'score_investment' }}>
-                                        Investment Score
-                                    </option>
-                                    <option value="score_lifestyle" {{ 'selected' if current_filters.sort_by == 'score_lifestyle' }}>
-                                        Lifestyle Score
-                                    </option>
-                                {% endif %}
-                                <!-- Other sort options -->
-                                <option value="price" {{ 'selected' if current_filters.sort_by == 'price' }}>
-                                    {{ t('price') }}
-                                </option>
-                                <option value="area" {{ 'selected' if current_filters.sort_by == 'area' }}>
-                                    {{ t('area') }}
-                                </option>
-                                <option value="travel_time_nearest_beach" {{ 'selected' if current_filters.sort_by == 'travel_time_nearest_beach' }}>
-                                    {{ t('beach_distance') }}
-                                </option>
-                                <option value="created_at" {{ 'selected' if current_filters.sort_by == 'created_at' }}>
-                                    {{ t('date_added') }}
-                                </option>
-                            </select>
-                        </div>
-                        <!-- Sort Direction Buttons -->
-                        <div style="display: flex; flex-direction: column; gap: var(--md-sys-spacing-1);">
-                            <button type="submit" class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.order == 'desc' else '' }}" 
-                                    onclick="document.querySelector('input[name=order]').value='desc'" 
-                                    title="{{ t('sort_descending') }}">
-                                <span class="material-symbols-outlined">arrow_downward</span>
-                            </button>
-                            <button type="submit" class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.order == 'asc' else '' }}" 
-                                    onclick="document.querySelector('input[name=order]').value='asc'" 
-                                    title="{{ t('sort_ascending') }}">
-                                <span class="material-symbols-outlined">arrow_upward</span>
-                            </button>
-                        </div>
+                            <option value="score_lifestyle" {{ 'selected' if current_filters.sort_by == 'score_lifestyle' }}>
+                                Lifestyle Score
+                            </option>
+                            <option value="score_total" {{ 'selected' if current_filters.sort_by == 'score_total' }}>
+                                Combined Score
+                            </option>
+                        {% elif current_filters.mode == 'lifestyle' %}
+                            <option value="score_lifestyle" {{ 'selected' if current_filters.sort_by == 'score_lifestyle' }}>
+                                Lifestyle Score
+                            </option>
+                            <option value="score_investment" {{ 'selected' if current_filters.sort_by == 'score_investment' }}>
+                                Investment Score
+                            </option>
+                            <option value="score_total" {{ 'selected' if current_filters.sort_by == 'score_total' }}>
+                                Combined Score
+                            </option>
+                        {% else %}
+                            <option value="score_total" {{ 'selected' if current_filters.sort_by == 'score_total' }}>
+                                Combined Score
+                            </option>
+                            <option value="score_investment" {{ 'selected' if current_filters.sort_by == 'score_investment' }}>
+                                Investment Score
+                            </option>
+                            <option value="score_lifestyle" {{ 'selected' if current_filters.sort_by == 'score_lifestyle' }}>
+                                Lifestyle Score
+                            </option>
+                        {% endif %}
+                        <option value="price" {{ 'selected' if current_filters.sort_by == 'price' }}>
+                            {{ t('price') }}
+                        </option>
+                        <option value="area" {{ 'selected' if current_filters.sort_by == 'area' }}>
+                            {{ t('area') }}
+                        </option>
+                        <option value="travel_time_nearest_beach" {{ 'selected' if current_filters.sort_by == 'travel_time_nearest_beach' }}>
+                            {{ t('beach_distance') }}
+                        </option>
+                        <option value="created_at" {{ 'selected' if current_filters.sort_by == 'created_at' }}>
+                            {{ t('date_added') }}
+                        </option>
+                    </select>
+                    <div class="filters-form__order">
+                        <button type="submit"
+                                class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.order == 'desc' else '' }}"
+                                onclick="document.querySelector('input[name=order]').value='desc'"
+                                title="{{ t('sort_descending') }}">
+                            <span class="material-symbols-outlined">arrow_downward</span>
+                        </button>
+                        <button type="submit"
+                                class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.order == 'asc' else '' }}"
+                                onclick="document.querySelector('input[name=order]').value='asc'"
+                                title="{{ t('sort_ascending') }}">
+                            <span class="material-symbols-outlined">arrow_upward</span>
+                        </button>
                         <input type="hidden" name="order" value="{{ current_filters.order or 'desc' }}">
                     </div>
                 </div>
-                        
-                    </div>
-                
-                <!-- MD3 Action Buttons and View Toggle -->
-                <div class="md3-card__actions" style="justify-content: space-between;">
-                    <div style="display: flex; gap: var(--md-sys-spacing-3);">
-                        <button type="submit" class="md3-button md3-button--filled">
-                            <span class="material-symbols-outlined">search</span>
-                            {{ t('apply') }}
-                        </button>
-                        <a href="{{ url_for('main.lands') }}" class="md3-button md3-button--outlined">
-                            <span class="material-symbols-outlined">clear</span>
-                            {{ t('clear') }}
-                        </a>
-                    </div>
-                    
-                    <!-- MD3 View Toggle -->
-                    <div style="display: flex; border: 1px solid var(--md-sys-color-outline-variant); border-radius: var(--md-sys-shape-corner-large); overflow: hidden;" role="group" aria-label="View type">
-                        <button type="button" 
-                                class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.view_type == 'list' else '' }}" 
-                                id="view-list-btn" 
-                                onclick="switchView('list')" 
-                                title="Table view - Compact data in rows"
-                                style="border-radius: 0; border: none; width: 48px; height: 48px;">
-                            <span class="material-symbols-outlined">view_list</span>
-                        </button>
-                        
-                        <button type="button" 
-                                class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.view_type == 'cards' or not current_filters.view_type else '' }}" 
-                                id="view-cards-btn" 
-                                onclick="switchView('cards')" 
-                                title="Card view - Visual property cards"
-                                style="border-radius: 0; border: none; border-left: 1px solid var(--md-sys-color-outline-variant); width: 48px; height: 48px;">
-                            <span class="material-symbols-outlined">view_module</span>
-                        </button>
-                    </div>
+
+                <div class="filters-form__actions-group">
+                    <button type="submit" class="md3-button md3-button--filled">
+                        <span class="material-symbols-outlined">search</span>
+                        {{ t('apply') }}
+                    </button>
+                    <a href="{{ url_for('main.lands') }}" class="md3-button md3-button--outlined">
+                        <span class="material-symbols-outlined">clear</span>
+                        {{ t('clear') }}
+                    </a>
                 </div>
-            </form>
-        </div>
-    </div>
+            </div>
+        </form>
+    </section>
 
     <!-- MD3 Properties Display -->
     {% if lands %}
         <!-- Results Summary and Mode Controls -->
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--md-sys-spacing-6);">
-            <div>
-                <h3 class="title-large" style="margin: 0;">{{ pagination.total }} {{ t('properties_found') }}</h3>
+        <div class="lands-results">
+            <div class="lands-results__summary">
+                <h3 class="title-large">{{ pagination.total }} {{ t('properties_found') }}</h3>
                 {% if filters_applied %}
-                    <p class="body-small" style="color: var(--md-sys-color-on-surface-variant); margin: 0;">(filtered)</p>
+                    <p class="body-small lands-results__status">(filtered)</p>
                 {% endif %}
             </div>
-            
-            <div style="display: flex; align-items: center; gap: var(--md-sys-spacing-4);">
-                <!-- MD3 Analysis Mode Toggle -->
-                <div style="display: flex; border: 1px solid var(--md-sys-color-outline-variant); border-radius: var(--md-sys-shape-corner-large); overflow: hidden;" role="group" aria-label="Analysis mode">
+
+            <div class="lands-results__controls">
+                <div class="toggle-group" role="group" aria-label="Analysis mode">
                     <button type="button"
                             class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.active_mode == 'combined' else '' }}"
                             onclick="switchMode('combined')"
                             id="mode-combined-btn"
-                            title="Combined Analysis - Shows overall property rating"
-                            style="border-radius: 0; border: none; width: 48px; height: 48px;">
+                            title="Combined Analysis - Shows overall property rating">
                         <span class="material-symbols-outlined">balance</span>
                     </button>
-                    <button type="button" 
+                    <button type="button"
                             class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.active_mode == 'investment' else '' }}"
-                            onclick="switchMode('investment')" 
+                            onclick="switchMode('investment')"
                             id="mode-investment-btn"
-                            title="Investment Analysis - Focus on rental yield and ROI"
-                            style="border-radius: 0; border: none; border-left: 1px solid var(--md-sys-color-outline-variant); width: 48px; height: 48px;">
+                            title="Investment Analysis - Focus on rental yield and ROI">
                         <span class="material-symbols-outlined">business_center</span>
                     </button>
-                    <button type="button" 
+                    <button type="button"
                             class="md3-button md3-button--icon{{ ' md3-button--filled' if current_filters.active_mode == 'lifestyle' else '' }}"
-                            onclick="switchMode('lifestyle')" 
+                            onclick="switchMode('lifestyle')"
                             id="mode-lifestyle-btn"
-                            title="Lifestyle Analysis - Focus on quality of life factors"
-                            style="border-radius: 0; border: none; border-left: 1px solid var(--md-sys-color-outline-variant); width: 48px; height: 48px;">
+                            title="Lifestyle Analysis - Focus on quality of life factors">
                             <span class="material-symbols-outlined">home</span>
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- add a dedicated `lands.css` stylesheet that harmonises spacing, filter controls, toggle groups, and results layout for the properties page
- expose `styles`/`body_attrs` injection points in the base template and rebuild the lands header, filters, and view/mode toggles to use the shared styles instead of inline rules
- keep the hidden `view_type` control in sync with the selected layout via a small `IdealistaApp` helper so filter submissions preserve the current view

## Testing
- pytest *(fails: missing `anthropic` and `flask` test dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c997bc20808329bfa170ccd919e3d8